### PR TITLE
feat: support inputs without version prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 semver
+!semver/

--- a/cmd/semver/semver.bats
+++ b/cmd/semver/semver.bats
@@ -26,6 +26,12 @@
   [ "$result" -eq 1  ]
 }
 
+@test run_without_version_prefix {
+  result=$(echo "1.2.3-beta2+build5" | ./semver)
+  [ "$?" -eq 0  ]
+  [ "$result" = '{"canonical":"1.2.3-beta2","major":"1","majorminor":"1.2","prerelease":"-beta2","build":"+build5","source":"1.2.3-beta2+build5"}' ]
+}
+
 @test run_without_with_bad_input {
   result=$(./semver <<<"abc"; echo $?)
   [ "$result" -eq 2  ]

--- a/versions/semantic.go
+++ b/versions/semantic.go
@@ -9,6 +9,8 @@ import (
 	"golang.org/x/mod/semver"
 )
 
+const versionPrefix = "v"
+
 type (
 	Canonical  string
 	Major      string
@@ -30,71 +32,38 @@ type SemanticVersion struct {
 	Value string
 }
 
-func (s *SemanticVersion) IsValid() bool {
-	if strings.HasPrefix(s.Value, "v") {
-		return semver.IsValid(s.Value)
+func restorePrefix(value string, f func(string) string) string {
+	if strings.HasPrefix(value, versionPrefix) {
+		return f(value)
 	}
-	return semver.IsValid(fmt.Sprintf("v%s", s.Value))
+	return strings.TrimPrefix(
+		f(fmt.Sprintf("%s%s", versionPrefix, value)),
+		versionPrefix,
+	)
+}
+
+func (s *SemanticVersion) IsValid() bool {
+	return semver.IsValid(s.Value) || semver.IsValid(fmt.Sprintf("%s%s", versionPrefix, s.Value))
 }
 
 func (s *SemanticVersion) Canonical() Canonical {
-	if strings.HasPrefix(s.Value, "v") {
-		return Canonical(semver.Canonical(s.Value))
-	}
-	return Canonical(
-		strings.TrimPrefix(
-			semver.Canonical(fmt.Sprintf("v%s", s.Value)),
-			"v",
-		),
-	)
+	return Canonical(restorePrefix(s.Value, semver.Canonical))
 }
 
 func (s *SemanticVersion) Major() Major {
-	if strings.HasPrefix(s.Value, "v") {
-		return Major(semver.Major(s.Value))
-	}
-	return Major(
-		strings.TrimPrefix(
-			semver.Major(fmt.Sprintf("v%s", s.Value)),
-			"v",
-		),
-	)
+	return Major(restorePrefix(s.Value, semver.Major))
 }
 
 func (s *SemanticVersion) MajorMinor() MajorMinor {
-	if strings.HasPrefix(s.Value, "v") {
-		return MajorMinor(semver.MajorMinor(s.Value))
-	}
-	return MajorMinor(
-		strings.TrimPrefix(
-			semver.MajorMinor(fmt.Sprintf("v%s", s.Value)),
-			"v",
-		),
-	)
+	return MajorMinor(restorePrefix(s.Value, semver.MajorMinor))
 }
 
 func (s *SemanticVersion) Prerelease() Prerelease {
-	if strings.HasPrefix(s.Value, "v") {
-		return Prerelease(semver.Prerelease(s.Value))
-	}
-	return Prerelease(
-		strings.TrimPrefix(
-			semver.Prerelease(fmt.Sprintf("v%s", s.Value)),
-			"v",
-		),
-	)
+	return Prerelease(restorePrefix(s.Value, semver.Prerelease))
 }
 
 func (s *SemanticVersion) Build() Build {
-	if strings.HasPrefix(s.Value, "v") {
-		return Build(semver.Build(s.Value))
-	}
-	return Build(
-		strings.TrimPrefix(
-			semver.Build(fmt.Sprintf("v%s", s.Value)),
-			"v",
-		),
-	)
+	return Build(restorePrefix(s.Value, semver.Build))
 }
 
 func (s SemanticVersion) String() string {

--- a/versions/semantic.go
+++ b/versions/semantic.go
@@ -30,12 +30,72 @@ type SemanticVersion struct {
 	Value string
 }
 
-func (s *SemanticVersion) IsValid() bool          { return bool(semver.IsValid(s.Value)) }
-func (s *SemanticVersion) Canonical() Canonical   { return Canonical(semver.Canonical(s.Value)) }
-func (s *SemanticVersion) Major() Major           { return Major(semver.Major(s.Value)) }
-func (s *SemanticVersion) MajorMinor() MajorMinor { return MajorMinor(semver.MajorMinor(s.Value)) }
-func (s *SemanticVersion) Prerelease() Prerelease { return Prerelease(semver.Prerelease(s.Value)) }
-func (s *SemanticVersion) Build() Build           { return Build(semver.Build(s.Value)) }
+func (s *SemanticVersion) IsValid() bool {
+	if strings.HasPrefix(s.Value, "v") {
+		return semver.IsValid(s.Value)
+	}
+	return semver.IsValid(fmt.Sprintf("v%s", s.Value))
+}
+
+func (s *SemanticVersion) Canonical() Canonical {
+	if strings.HasPrefix(s.Value, "v") {
+		return Canonical(semver.Canonical(s.Value))
+	}
+	return Canonical(
+		strings.TrimPrefix(
+			semver.Canonical(fmt.Sprintf("v%s", s.Value)),
+			"v",
+		),
+	)
+}
+
+func (s *SemanticVersion) Major() Major {
+	if strings.HasPrefix(s.Value, "v") {
+		return Major(semver.Major(s.Value))
+	}
+	return Major(
+		strings.TrimPrefix(
+			semver.Major(fmt.Sprintf("v%s", s.Value)),
+			"v",
+		),
+	)
+}
+
+func (s *SemanticVersion) MajorMinor() MajorMinor {
+	if strings.HasPrefix(s.Value, "v") {
+		return MajorMinor(semver.MajorMinor(s.Value))
+	}
+	return MajorMinor(
+		strings.TrimPrefix(
+			semver.MajorMinor(fmt.Sprintf("v%s", s.Value)),
+			"v",
+		),
+	)
+}
+
+func (s *SemanticVersion) Prerelease() Prerelease {
+	if strings.HasPrefix(s.Value, "v") {
+		return Prerelease(semver.Prerelease(s.Value))
+	}
+	return Prerelease(
+		strings.TrimPrefix(
+			semver.Prerelease(fmt.Sprintf("v%s", s.Value)),
+			"v",
+		),
+	)
+}
+
+func (s *SemanticVersion) Build() Build {
+	if strings.HasPrefix(s.Value, "v") {
+		return Build(semver.Build(s.Value))
+	}
+	return Build(
+		strings.TrimPrefix(
+			semver.Build(fmt.Sprintf("v%s", s.Value)),
+			"v",
+		),
+	)
+}
 
 func (s SemanticVersion) String() string {
 	return fmt.Sprintf("%s", s.Value)
@@ -55,14 +115,6 @@ func (s SemanticVersion) MarshalJSON() ([]byte, error) {
 
 func (s SemanticVersion) MarshalEVAL() ([]byte, error) {
 	var out string
-
-	//	var properties []func() string = []func() string{
-	//		s.Major, s.MajorMinor, s.Canonical, s.Prerelease, s.Build,
-	//	}
-	//
-	//	for _, fn := range properties {
-	//		out = fmt.Sprintf("%s\nexport MAJOR='%s'", out, shellescape.Quote(s.Major()))
-	//	}
 
 	out = fmt.Sprintf("%s\nexport MAJOR='%s'", out, string(s.Major()))
 	out = fmt.Sprintf("%s\nexport MAJORMINOR='%s'", out, string(s.MajorMinor()))


### PR DESCRIPTION
Previously, passing an input without a 'v' prefix (ex: 1.2.3 instead of v1.2.3) would fail due to limitations of the golang semver library.

This change allows these types of inputs to be supported by checking whether the prefix exists and conditionally trimming the final output to match the user's input.

The regex should be explicit enough that it never over-matches but TBH still feels a little iffy. I had a more robust solution but this involved adding some struct fields and quite significantly altering the JSON / eval marshal functions which felt like a little too much for such a small feature.